### PR TITLE
Remove metadata of Alpine Linux.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,9 +11,6 @@ galaxy_info:
     - name: Darwin
       versions:
         - all
-    - name: Alpine
-      versions:
-        - 3.3
 
   galaxy_tags:
     - development


### PR DESCRIPTION
Ansible Galaxy checks platform value now, and it can't accept Alpine
Linux.
